### PR TITLE
err

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -371,7 +371,7 @@ class build_ext(build_ext_):
         else:
             openmpflag = "-fopenmp"
             archi = platform.machine()
-            if archi in ("i386", "x86_64"):
+            if archi in ("i386", "x86_64", "loongarch64"):
                 compileflags = COMPILE_FLAGS + ["-march=%s" % self.march]
             else:
                 compileflags = COMPILE_FLAGS + ["-mcpu=%s" % self.march]


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

You can use it on x86_64  machine with docker run -it --rm merore/archlinux-loongarch64.
About this image:
- Boot an Loongarch64-based Arch Linux with qemu-system-loongarch64
- The default user/password is root/loongarch64
- All dependcies required by criu build and test are pre-installed
- You must configure your own dependence on the environment, Golang's installation package is located at http://ftp.loongnix.cn/toolchain/golang/go-1.20/abi2.0/go1.20.2.linux-loong64.tar.gz

Finally, thank you for your patience !
